### PR TITLE
feat(api): expose Actuator health and info endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,20 @@ See the living roadmap for planned improvements: [ROADMAP.md](./ROADMAP.md).
 
 ---
 
+## Health Check
+
+The application exposes two Actuator endpoints for operational visibility:
+
+-   **Health Status:** Check if the application is running.
+    ```sh
+    curl http://localhost:8080/actuator/health
+    ```
+
+-   **Application Info:** Get basic build information.
+    ```sh
+    curl http://localhost:8080/actuator/info
+    ```
+
 ## 📄 License
 
 This project is licensed under the MIT License. See the `LICENSE` file for more details.

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,57 @@
+# First Task from Roadmap (M0)
+
+Title: Expose Health and Info Endpoints via Spring Boot Actuator
+
+Context: From ROADMAP.md → M0 — Foundation hardening. One of the earliest deliverables is to provide basic health endpoints and app info so the service can be monitored and verified in different environments.
+
+Why: This gives immediate operational visibility with minimal code impact and helps validate that the service is up after deploys. It also sets the stage for later observability work.
+
+Scope:
+- Add Spring Boot Actuator dependency.
+- Expose `/actuator/health` and `/actuator/info` over HTTP.
+- Include basic build/app info (name, version) in `/actuator/info`.
+- Ensure endpoints are visible in dev by default; keep production exposure configurable via properties.
+
+Deliverables:
+- Dependency: `org.springframework.boot:spring-boot-starter-actuator`.
+- Configuration in `application.properties` (dev defaults):
+  - `management.endpoints.web.exposure.include=health,info`
+  - `management.endpoint.health.probes.enabled=true`
+  - Optional: `management.endpoint.health.show-details=when_authorized` (or `always` for dev)
+- Build metadata in `/actuator/info` (choose one):
+  - Use Spring Boot Gradle plugin’s `springBoot { buildInfo() }` and ensure the build task generates `META-INF/build-info.properties`.
+  - Or add minimal custom application info properties (app.name, app.version) to be mapped into `info` via `info.*` properties.
+- README update: Add a short “Health Check” subsection under API or Operations with example curl calls.
+
+Acceptance Criteria:
+- `GET /actuator/health` returns 200 with `{"status":"UP"}` in a running local dev instance.
+- `GET /actuator/info` returns 200 with at least name and version fields (from build info or properties).
+- Tests still pass (`./gradlew test`).
+- No endpoints other than `health` and `info` are exposed by default in dev config.
+
+Out of Scope (for future tasks):
+- Authentication/authorization for Actuator endpoints.
+- Additional endpoints like metrics or env.
+- Structured JSON logging; to be handled in separate task per M0.
+
+Proposed Branch Name:
+- `feat/actuator-health-endpoints`
+
+Proposed First Commit Message (Conventional Commits):
+- `feat(api): expose Actuator health and info endpoints with basic app info`
+
+Implementation Notes:
+- In `build.gradle.kts` add:
+  - `implementation("org.springframework.boot:spring-boot-starter-actuator")`
+  - Inside `springBoot {}` block add `buildInfo()` to generate build metadata, then ensure that `bootRun` depends on tasks that generate build info (usually handled automatically when building).
+- In `src/main/resources/application.properties` add the management.* keys listed above.
+- Optionally, restrict exposure per profile (e.g., leave minimal exposure in `application.properties` and override in `application-prod.properties`).
+
+How to Start Locally:
+1) Create branch: `git checkout -b feat/actuator-health-endpoints`
+2) Add dependency + properties as described.
+3) Run: `./gradlew bootRun`
+4) Verify:
+   - `curl -s http://localhost:8080/actuator/health`
+   - `curl -s http://localhost:8080/actuator/info`
+5) Commit with the provided message and push branch.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ repositories {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
     annotationProcessor("org.projectlombok:lombok")
     compileOnly("org.projectlombok:lombok")
     runtimeOnly("com.h2database:h2")
@@ -36,6 +37,10 @@ tasks.withType<Test> {
 
 tasks.named("check") {
     dependsOn("pmdMain", "pmdTest", "spotlessApply")
+}
+
+springBoot {
+    buildInfo()
 }
 
 spotless {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,6 @@ spring.datasource.url=jdbc:h2:mem:testdb
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
+
+management.endpoints.web.exposure.include=health,info
+management.endpoint.health.probes.enabled=true


### PR DESCRIPTION
This PR adds the Spring Boot Actuator to expose  and  endpoints for operational visibility. It includes basic build information generated by the Spring Boot Gradle plugin and updates the README with usage examples.