### PR TITLE
feat(observability): Add correlation ID and JSON logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ gradle-app.setting
 # Windows system files
 Thumbs.db
 ehthumbs.db
-Desktop.ini
+Desktop.iniŌ
 
 ### Log and Temp Files ###
 *.log
@@ -43,3 +43,5 @@ Desktop.ini
 *.jar
 *.war
 *.ear
+
+tasks.md

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("net.logstash.logback:logstash-logback-encoder:8.1")
     annotationProcessor("org.projectlombok:lombok")
     compileOnly("org.projectlombok:lombok")
     runtimeOnly("com.h2database:h2")

--- a/src/main/java/io/github/tomaszziola/javabuildautomaton/config/CorrelationIdFilter.java
+++ b/src/main/java/io/github/tomaszziola/javabuildautomaton/config/CorrelationIdFilter.java
@@ -1,0 +1,50 @@
+package io.github.tomaszziola.javabuildautomaton.config;
+
+import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@Order(HIGHEST_PRECEDENCE + 10)
+public class CorrelationIdFilter extends OncePerRequestFilter {
+
+  public static final String CORRELATION_ID_HEADER = "X-Correlation-Id";
+  public static final String MDC_KEY = "correlationId";
+
+  @Override
+  protected void doFilterInternal(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final FilterChain filterChain)
+      throws ServletException, IOException {
+
+    String correlationId = getOrGenerateCorrelationId(request);
+
+    MDC.put(MDC_KEY, correlationId);
+    response.setHeader(CORRELATION_ID_HEADER, correlationId);
+
+    try {
+      filterChain.doFilter(request, response);
+    } finally {
+      MDC.remove(MDC_KEY);
+    }
+  }
+
+  private String getOrGenerateCorrelationId(final HttpServletRequest request) {
+    final String headerValue = request.getHeader(CORRELATION_ID_HEADER);
+    if (headerValue != null && !headerValue.isBlank()) {
+      return headerValue;
+    }
+    return UUID.randomUUID().toString();
+  }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true">
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp>
+                    <timeZone>UTC</timeZone>
+                </timestamp>
+                <logLevel/>
+                <loggerName/>
+                <threadName/>
+                <message/>
+                <mdc>
+                    <includeMdcKeyName>correlationId</includeMdcKeyName>
+                </mdc>
+                <stackTrace/>
+            </providers>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
This PR introduces structured JSON logging via Logback and a correlation ID filter. Each request is now assigned a unique ID (from the X-Correlation-Id header or generated), which is included in all log entries for easier tracing. Completes the structured logging task.