### PR TITLE
Refactor: move repository access from controller to service

### DIFF
--- a/src/main/java/io/github/tomaszziola/javabuildautomaton/project/ProjectApiController.java
+++ b/src/main/java/io/github/tomaszziola/javabuildautomaton/project/ProjectApiController.java
@@ -2,11 +2,6 @@ package io.github.tomaszziola.javabuildautomaton.project;
 
 import io.github.tomaszziola.javabuildautomaton.api.dto.BuildSummaryDto;
 import io.github.tomaszziola.javabuildautomaton.api.dto.ProjectDetailsDto;
-import io.github.tomaszziola.javabuildautomaton.buildsystem.BuildMapper;
-import io.github.tomaszziola.javabuildautomaton.buildsystem.BuildRepository;
-import io.github.tomaszziola.javabuildautomaton.buildsystem.entity.Build;
-import io.github.tomaszziola.javabuildautomaton.project.entity.Project;
-import io.github.tomaszziola.javabuildautomaton.project.exception.ProjectNotFoundException;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,35 +12,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/projects")
 public class ProjectApiController {
 
-  private final BuildMapper buildMapper;
-  private final ProjectMapper projectMapper;
-  private final ProjectRepository projectRepository;
-  private final BuildRepository buildRepository;
+  private final ProjectService projectService;
 
-  public ProjectApiController(
-      final BuildMapper buildMapper,
-      final ProjectMapper mapper,
-      final ProjectRepository projectRepository,
-      final BuildRepository buildRepository) {
-    this.buildMapper = buildMapper;
-    this.projectMapper = mapper;
-    this.projectRepository = projectRepository;
-    this.buildRepository = buildRepository;
+  public ProjectApiController(final ProjectService projectService) {
+    this.projectService = projectService;
   }
 
   @GetMapping
   public List<ProjectDetailsDto> getAllProjects() {
-    return projectRepository.findAll().stream().map(projectMapper::toDetailsDto).toList();
+    return projectService.findAll();
   }
 
   @GetMapping("/{projectId}/builds")
   public List<BuildSummaryDto> getProjectBuilds(@PathVariable final Long projectId) {
-    final Project project =
-        projectRepository
-            .findById(projectId)
-            .orElseThrow(() -> new ProjectNotFoundException(projectId));
-
-    final List<Build> builds = buildRepository.findByProject(project);
-    return builds.stream().map(buildMapper::toSummaryDto).toList();
+    return projectService.findProjectBuilds(projectId);
   }
 }

--- a/src/test/java/io/github/tomaszziola/javabuildautomaton/project/ProjectApiControllerTest.java
+++ b/src/test/java/io/github/tomaszziola/javabuildautomaton/project/ProjectApiControllerTest.java
@@ -1,6 +1,5 @@
 package io.github.tomaszziola.javabuildautomaton.project;
 
-import static io.github.tomaszziola.javabuildautomaton.buildsystem.BuildStatus.SUCCESS;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -19,11 +18,7 @@ class ProjectApiControllerTest extends BaseUnit {
     // then
     assertThat(result.size()).isEqualTo(1);
     final ProjectDetailsDto first = result.getFirst();
-    assertThat(first.id()).isEqualTo(project.getId());
-    assertThat(first.name()).isEqualTo(project.getName());
-    assertThat(first.repositoryName()).isEqualTo(project.getRepositoryName());
-    assertThat(first.localPath()).isEqualTo(project.getLocalPath());
-    assertThat(first.buildTool()).isEqualTo(project.getBuildTool());
+    assertThat(first).isEqualTo(projectDetailsDto);
   }
 
   @Test
@@ -33,10 +28,7 @@ class ProjectApiControllerTest extends BaseUnit {
 
     // then
     assertThat(result.size()).isEqualTo(1);
-    assertThat(result.getFirst().id()).isEqualTo(1L);
-    assertThat(result.getFirst().startTime()).isEqualTo(build.getStartTime());
-    assertThat(result.getFirst().endTime()).isEqualTo(build.getEndTime());
-    assertThat(result.getFirst().status()).isEqualTo(SUCCESS);
+    assertThat(result.getFirst()).isEqualTo(buildSummaryDto);
   }
 
   @Test

--- a/src/test/java/io/github/tomaszziola/javabuildautomaton/project/ProjectServiceTest.java
+++ b/src/test/java/io/github/tomaszziola/javabuildautomaton/project/ProjectServiceTest.java
@@ -2,8 +2,10 @@ package io.github.tomaszziola.javabuildautomaton.project;
 
 import static io.github.tomaszziola.javabuildautomaton.api.dto.ApiStatus.NOT_FOUND;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
+import io.github.tomaszziola.javabuildautomaton.project.exception.ProjectNotFoundException;
 import io.github.tomaszziola.javabuildautomaton.utils.BaseUnit;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -32,5 +34,31 @@ class ProjectServiceTest extends BaseUnit {
     assertThat(result.status()).isEqualTo(NOT_FOUND);
     assertThat(result.message())
         .isEqualTo("Project not found for repository: " + payload.repository().fullName());
+  }
+
+  @Test
+  void givenGetRequest_whenFindAll_thenReturnListOfProjectDetailsDto() {
+    // when
+    final var result = projectServiceImpl.findAll();
+
+    // then
+    assertThat(result.getFirst()).isEqualTo(projectDetailsDto);
+  }
+
+  @Test
+  void givenExistingProjectId_whenFindProjectBuilds_thenReturnListOfBuildSummaryDto() {
+    // when
+    final var result = projectServiceImpl.findProjectBuilds(projectId);
+
+    // then
+    assertThat(result.getFirst()).isEqualTo(buildSummaryDto);
+  }
+
+  @Test
+  void givenNotExistingProject_whenFindProjectBuilds_thenThrowProjectNotFoundException() {
+    // when / then
+    assertThrows(
+        ProjectNotFoundException.class,
+        () -> projectServiceImpl.findProjectBuilds(nonExistentProjectId));
   }
 }


### PR DESCRIPTION
This refactors the ProjectApiController to delegate persistence to the service layer, improving separation of concerns and testability.