### PR TITLE
chore(db): Add Flyway for database versioning

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,9 +31,11 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("net.logstash.logback:logstash-logback-encoder:8.1")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
+    implementation("org.flywaydb:flyway-core:11.11.2")
+    runtimeOnly("org.postgresql:postgresql")
+    runtimeOnly("com.h2database:h2")
     annotationProcessor("org.projectlombok:lombok")
     compileOnly("org.projectlombok:lombok")
-    runtimeOnly("com.h2database:h2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 

--- a/src/main/java/io/github/tomaszziola/javabuildautomaton/buildsystem/entity/Build.java
+++ b/src/main/java/io/github/tomaszziola/javabuildautomaton/buildsystem/entity/Build.java
@@ -1,6 +1,8 @@
 package io.github.tomaszziola.javabuildautomaton.buildsystem.entity;
 
 import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.SEQUENCE;
 
 import io.github.tomaszziola.javabuildautomaton.buildsystem.BuildStatus;
 import io.github.tomaszziola.javabuildautomaton.project.entity.Project;
@@ -9,10 +11,12 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
 import java.time.Instant;
 import lombok.Getter;
 import lombok.Setter;
@@ -23,9 +27,12 @@ import org.hibernate.proxy.HibernateProxy;
 @Setter
 public class Build {
 
-  @Id @GeneratedValue private Long id;
+  @Id
+  @SequenceGenerator(name = "build_sq", sequenceName = "build_sq", allocationSize = 1)
+  @GeneratedValue(strategy = SEQUENCE, generator = "build_sq")
+  private Long id;
 
-  @ManyToOne(fetch = FetchType.LAZY)
+  @ManyToOne(fetch = LAZY)
   @JoinColumn(name = "project_id", nullable = false)
   private Project project;
 

--- a/src/main/java/io/github/tomaszziola/javabuildautomaton/project/entity/Project.java
+++ b/src/main/java/io/github/tomaszziola/javabuildautomaton/project/entity/Project.java
@@ -1,12 +1,14 @@
 package io.github.tomaszziola.javabuildautomaton.project.entity;
 
 import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.GenerationType.SEQUENCE;
 
 import io.github.tomaszziola.javabuildautomaton.buildsystem.BuildTool;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,7 +21,11 @@ import org.hibernate.proxy.HibernateProxy;
 @NoArgsConstructor
 @AllArgsConstructor
 public class Project {
-  @Id @GeneratedValue private Long id;
+
+  @Id
+  @SequenceGenerator(name = "project_sq", sequenceName = "project_sq", allocationSize = 1)
+  @GeneratedValue(strategy = SEQUENCE, generator = "project_sq")
+  private Long id;
   private String name;
   private String repositoryName;
   private String localPath;

--- a/src/main/java/io/github/tomaszziola/javabuildautomaton/webui/WebUiController.java
+++ b/src/main/java/io/github/tomaszziola/javabuildautomaton/webui/WebUiController.java
@@ -1,6 +1,8 @@
 package io.github.tomaszziola.javabuildautomaton.webui;
 
 import io.github.tomaszziola.javabuildautomaton.project.ProjectService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,12 @@
+spring.datasource.url=${JDBC_CONNECTION_STRING}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
+
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+spring.jpa.hibernate.ddl-auto=none
+
+spring.flyway.enabled=true
+spring.h2.console.enabled=false
+
+spring.sql.init.mode=never

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,3 +11,4 @@ management.endpoints.web.exposure.include=health,info
 management.endpoint.health.probes.enabled=true
 
 spring.profiles.active=dev
+spring.flyway.enabled=true

--- a/src/main/resources/db/migration/V1_0_0__create_project.sql
+++ b/src/main/resources/db/migration/V1_0_0__create_project.sql
@@ -1,0 +1,10 @@
+CREATE SEQUENCE public.project_sq INCREMENT 1 START WITH 1 MINVALUE 1;
+
+CREATE TABLE project
+(
+    id              BIGINT PRIMARY KEY,
+    name            VARCHAR(255),
+    repository_name VARCHAR(255),
+    local_path      VARCHAR(255),
+    build_tool      VARCHAR(255)
+);

--- a/src/main/resources/db/migration/V1_1_0__create_build.sql
+++ b/src/main/resources/db/migration/V1_1_0__create_build.sql
@@ -1,0 +1,12 @@
+CREATE SEQUENCE public.build_sq INCREMENT 1 START WITH 1 MINVALUE 1;
+
+CREATE TABLE build
+(
+    id         BIGINT PRIMARY KEY,
+    project_id BIGINT NOT NULL,
+    status     VARCHAR(255),
+    start_time TIMESTAMP,
+    end_time   TIMESTAMP,
+    logs       TEXT,
+    CONSTRAINT fk_project FOREIGN KEY (project_id) REFERENCES project (id)
+);


### PR DESCRIPTION
This PR introduces Flyway to manage database schema evolution. It includes the initial schema migration for the Project and Build tables and configures the application to use Flyway for both dev (H2) and prod (PostgreSQL) environments. Completes JBA-22.